### PR TITLE
in VS 2017 the library failed to compile... this correction seems to solve the problem

### DIFF
--- a/Requests/PartsRequest.cs
+++ b/Requests/PartsRequest.cs
@@ -1,10 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
+using Octosharp.Responses;
 
 namespace Octosharp.Requests
 {
     //example: http://octopart.com/api/v3/parts/103cdb613d20cffb?apikey=APIKEYGOESHERE
-    public class PartsRequest : IOctoRequest<>
+    public class PartsRequest : IOctoRequest<OctoJsonResponse>
     {
         private readonly string _endpoint;
 


### PR DESCRIPTION
not sure if my correction is correct but the proposed correction compile now. 
I don't have VS2013 to test if that issue is related to the version of VS